### PR TITLE
Install 'ncclient' and dependencies (libxml2 and libxslt) in ansible-silo-base image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Silo is based on **[Alpine Linux] 3.6** and includes the following APK packages:
  - libbz2 1.0.6-r5
  - libcurl 7.55.0-r0
  - libffi 3.2.1-r3
+ - libxml2 2.9.4-r4
+ - libxslt 1.1.29-r3
  - libssh2 1.8.0-r1
  - ncurses-libs 6.0-r8
  - ncurses-terminfo 6.0-r8

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -103,7 +103,9 @@ RUN echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/
                        zlib-dev=1.2.11-r0\
                        python2-dev=2.7.13-r1\
                        openssl-dev=1.0.2k-r0\
-                       libffi-dev=3.2.1-r3 &&\
+                       libffi-dev=3.2.1-r3\
+                       libxml2-dev=2.9.4-r4\
+                       libxslt-dev=1.1.29-r3 &&\
 
     pip install asn1crypto==0.22.0\
                 cffi==1.10.0\
@@ -111,6 +113,8 @@ RUN echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/
                 enum34==1.1.6\
                 idna==2.5\
                 ipaddress==1.0.18\
+                ncclient==0.5.3\
+                paramiko==1.16.0\
                 pycparser==2.18\
                 pycrypto==2.6.1\
                 six==1.10.0 &&\
@@ -131,7 +135,9 @@ RUN echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/
                        zlib-dev\
                        python2-dev\
                        openssl-dev\
-                       libffi-dev &&\
+                       libffi-dev\
+                       libxml2-dev\
+                       libxslt-dev &&\
 
  # Install docker command and ensure it's always executed w/ sudo
     curl -fL -o /tmp/docker.tgz "https://download.docker.com/linux/static/stable/x86_64/docker-17.06.0-ce.tgz" &&\

--- a/tests/functional
+++ b/tests/functional
@@ -424,6 +424,12 @@ test_silo_bundle_function() {
   run "$BATS_ANSIBLE_SILO_INSTALL_PATH/ansible" -i localhost, -c local \
     -m blockinfile -a "dest=/tmp/blockinfile.test block=content create=yes" all
   [[ "${status}" -eq 0 ]]
+
+  # TODO: commented out until ansible-silo-base is updated
+  # # Make sure we can import the ncclient module added to ansible-silo-base
+  # run "$BATS_ANSIBLE_SILO_INSTALL_PATH/ansible-silo" --shell "python -c 'import ncclient; print ncclient'"
+  # [[ "${status}" -eq 0 ]]
+  # [[ "${lines[-1]}" == *$"<module 'ncclient' from '/silo/userspace/lib/python2.7/site-packages/ncclient/__init__.py"* ]]
 }
 
 @test "Shell execution" {


### PR DESCRIPTION
'ncclient' is used by many of the networking ansible modules.

Note that BATS tests for the existence of 'ncclient' are in
tests/functional but commented out since they'll fail until the
ansible-silo-base image is updated.